### PR TITLE
Change test flags to have more descriptive names.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ go:
   - master
 
 script:
-  - go install
+  - go test -service-start-delay 1000ms -http-client-timeout 10000ms

--- a/hoster_test.go
+++ b/hoster_test.go
@@ -32,8 +32,8 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	flag.DurationVar(&serviceStartDelay, "delay", serviceStartDelay, "time to delay in milliseconds so test service can start")
-	flag.DurationVar(&httpClientTimeout, "timeout", httpClientTimeout, "http client timeout in milliseconds")
+	flag.DurationVar(&serviceStartDelay, "service-start-delay", serviceStartDelay, "time to delay in milliseconds so test service can start")
+	flag.DurationVar(&httpClientTimeout, "http-client-timeout", httpClientTimeout, "http client timeout in milliseconds")
 	flag.Parse()
 
 	os.Exit(m.Run())


### PR DESCRIPTION
Timeout was not working because go test already had a timeout flag.