### PR TITLE
Rename functions for registering grpc servers and http gateways

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: go
 
 go:
-  - 1.8.x
   - 1.9.x
   - 1.10.x
   - master

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -19,14 +19,14 @@
     "ptypes/struct",
     "ptypes/timestamp"
   ]
-  revision = "925541529c1fa6821df4e44ce2723319eb2be768"
-  version = "v1.0.0"
+  revision = "b4deda0973fb4c70b50d226b1af49f3da59f5265"
+  version = "v1.1.0"
 
 [[projects]]
   branch = "master"
   name = "github.com/grpc-ecosystem/go-grpc-middleware"
   packages = ["."]
-  revision = "eb23b08d08bbe930113a6512a7a829050341448c"
+  revision = "e9c5d9645c437ab1b204cff969a2c0fb16cd4276"
 
 [[projects]]
   name = "github.com/grpc-ecosystem/grpc-gateway"
@@ -35,8 +35,8 @@
     "runtime/internal",
     "utilities"
   ]
-  revision = "07f5e79768022f9a3265235f0db4ac8c3f675fec"
-  version = "v1.3.1"
+  revision = "92583770e3f01b09a0d3e9bdf64321d8bebd48f2"
+  version = "v1.4.1"
 
 [[projects]]
   name = "github.com/pmezard/go-difflib"
@@ -50,22 +50,22 @@
     "assert",
     "require"
   ]
-  revision = "12b6f73e6084dad08a7c6e575284b177ecafbc71"
-  version = "v1.2.1"
+  revision = "f35b8ab0b5a2cef36673838d662e249dd9c94686"
+  version = "v1.2.2"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/net"
   packages = [
     "context",
+    "http/httpguts",
     "http2",
     "http2/hpack",
     "idna",
     "internal/timeseries",
-    "lex/httplex",
     "trace"
   ]
-  revision = "d25186b37f34ebdbbea8f488ef055638dfab272d"
+  revision = "a680a1efc54dd51c040b3b5ce4939ea3cf2ea0d1"
 
 [[projects]]
   name = "golang.org/x/text"
@@ -95,7 +95,7 @@
     "googleapis/api/annotations",
     "googleapis/rpc/status"
   ]
-  revision = "df60624c1e9b9d2973e889c7a1cff73155da81c4"
+  revision = "fedd2861243fd1a8152376292b921b394c7bef7e"
 
 [[projects]]
   name = "google.golang.org/grpc"
@@ -109,9 +109,11 @@
     "credentials",
     "encoding",
     "encoding/proto",
-    "grpclb/grpc_lb_v1/messages",
     "grpclog",
     "internal",
+    "internal/backoff",
+    "internal/channelz",
+    "internal/grpcrand",
     "keepalive",
     "metadata",
     "naming",
@@ -124,12 +126,12 @@
     "tap",
     "transport"
   ]
-  revision = "8e4536a86ab602859c20df5ebfd0bd4228d08655"
-  version = "v1.10.0"
+  revision = "168a6198bcb0ef175f7dacec0b8691fc141dc9b8"
+  version = "v1.13.0"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "b0abd303f7a09f6e4a7907929e0c1d15dfd2a92d2ccaad8e3f17a5e0ab572c46"
+  inputs-digest = "e43fb24dceadffa75f5cdd6acd4b2162b922b5e0199ebdaf11b12304053952d6"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -51,7 +51,7 @@
 
 [[constraint]]
   name = "google.golang.org/grpc"
-  version = "1.10.0"
+  version = "1.9.0"
 
 [prune]
   go-tests = true

--- a/README.md
+++ b/README.md
@@ -65,11 +65,11 @@ hoster.InsecureSkipVerify = *insecureSkipVerify
 hoster.MaxSendMsgSize = *maxSendMsgSize
 hoster.MaxRecvMsgSize = *maxRecvMsgSize
 
-hoster.RegisterGRPCEndpoint(func(s *grpc.Server) {
+hoster.RegisterGRPCServer(func(s *grpc.Server) {
 	pb.RegisterHelloServiceServer(s, service)
 })
 
-hoster.RegisterHTTPEndpoint(pb.RegisterHelloServiceHandlerFromEndpoint)
+hoster.RegisterHTTPGateway(pb.RegisterHelloServiceHandlerFromEndpoint)
 
 // start the server
 err := hoster.ListenAndServe()

--- a/examples/hello/cmd/server/main.go
+++ b/examples/hello/cmd/server/main.go
@@ -39,12 +39,13 @@ func main() {
 	hoster.MaxSendMsgSize = *maxSendMsgSize
 	hoster.MaxRecvMsgSize = *maxRecvMsgSize
 
-	hoster.RegisterGRPCEndpoint(func(s *grpc.Server) {
-		log.Printf("Registered gRPC endpoint at: %v", *grpcAddr)
+	hoster.RegisterGRPCServer(func(s *grpc.Server) {
 		pb.RegisterHelloServiceServer(s, service)
 	})
+	log.Printf("Registered gRPC endpoint at: %v", *grpcAddr)
 
-	hoster.RegisterHTTPEndpoint(pb.RegisterHelloServiceHandlerFromEndpoint)
+	hoster.RegisterHTTPGateway(pb.RegisterHelloServiceHandlerFromEndpoint)
+	log.Printf("Registered HTTP endpoint at: %v", *httpAddr)
 
 	// start the server
 	err := hoster.ListenAndServe()

--- a/examples/test/test_service.go
+++ b/examples/test/test_service.go
@@ -12,7 +12,7 @@ import (
 //go:generate protoc -I. -I$GOPATH/src/github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis --grpc-gateway_out=logtostderr=true:. proto/test.proto
 //go:generate protoc -I. -I$GOPATH/src/github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis --proto_path=./proto --swagger_out=logtostderr=true:. proto/test.proto
 
-// Service contains the implementation for the gRPC service. It implements the interfaces for both gRPC and HTTP endpoints.
+// Service contains the implementation for the gRPC service.
 type Service struct{}
 
 // NewService creates a new instance of Service.

--- a/hoster_grpc.go
+++ b/hoster_grpc.go
@@ -33,15 +33,13 @@ func (h *Hoster) serveGRPC() error {
 		opts = append(opts, streamInterceptorChain)
 	}
 
-	// start the gRPC endpoint
+	// add TLS credentials to options if necessary
 	if h.isTLSEnabled() {
-		// create TLS credentials
 		creds, err := credentials.NewServerTLSFromFile(h.CertFile, h.KeyFile)
 		if err != nil {
 			return fmt.Errorf("failed to load TLS credentials: %v", err)
 		}
 
-		// add TLS credentials to options
 		opts = append(opts, grpc.Creds(creds))
 	}
 
@@ -53,11 +51,11 @@ func (h *Hoster) serveGRPC() error {
 
 	// register servers
 	server := grpc.NewServer(opts...)
-	for i := range h.grpcEndpoints {
-		h.grpcEndpoints[i](server)
+	for i := range h.grpcServers {
+		h.grpcServers[i](server)
 	}
 
-	// start servers
+	// start the gRPC endpoint
 	return server.Serve(lis)
 }
 

--- a/hoster_http.go
+++ b/hoster_http.go
@@ -40,12 +40,12 @@ func (h *Hoster) serveHTTP() error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	// register servers
+	// register gateways
 	mux := runtime.NewServeMux()
-	for i := range h.httpEndpoints {
-		err := h.httpEndpoints[i](ctx, mux, h.GRPCAddr, opts)
+	for i := range h.httpGateways {
+		err := h.httpGateways[i](ctx, mux, h.GRPCAddr, opts)
 		if err != nil {
-			return fmt.Errorf("failed to register HTTP endpoint: %v", err)
+			return fmt.Errorf("failed to register HTTP gateway: %v", err)
 		}
 	}
 

--- a/test/hoster_grpc_test.go
+++ b/test/hoster_grpc_test.go
@@ -25,7 +25,7 @@ func Test_Hoster_ListenAndServe_GRPC_Successful(t *testing.T) {
 
 	hoster := gohost.NewHoster()
 	hoster.GRPCAddr = grpcAddr
-	hoster.RegisterGRPCEndpoint(func(s *grpc.Server) {
+	hoster.RegisterGRPCServer(func(s *grpc.Server) {
 		pb.RegisterTestServiceServer(s, service)
 	})
 
@@ -59,7 +59,7 @@ func Test_Hoster_ListenAndServe_GRPC_WithTLS(t *testing.T) {
 
 	hoster := gohost.NewHoster()
 	hoster.GRPCAddr = grpcAddr
-	hoster.RegisterGRPCEndpoint(func(s *grpc.Server) {
+	hoster.RegisterGRPCServer(func(s *grpc.Server) {
 		pb.RegisterTestServiceServer(s, service)
 	})
 
@@ -93,7 +93,7 @@ func Test_Hoster_ListenAndServe_GRPC_EmptyAddress(t *testing.T) {
 
 	hoster := gohost.NewHoster()
 	hoster.GRPCAddr = ""
-	hoster.RegisterGRPCEndpoint(func(s *grpc.Server) {
+	hoster.RegisterGRPCServer(func(s *grpc.Server) {
 		pb.RegisterTestServiceServer(s, service)
 	})
 
@@ -110,7 +110,7 @@ func Test_Hoster_ListenAndServe_GRPC_InvalidAddress(t *testing.T) {
 
 	hoster := gohost.NewHoster()
 	hoster.GRPCAddr = "badaddress"
-	hoster.RegisterGRPCEndpoint(func(s *grpc.Server) {
+	hoster.RegisterGRPCServer(func(s *grpc.Server) {
 		pb.RegisterTestServiceServer(s, service)
 	})
 
@@ -128,7 +128,7 @@ func Test_Hoster_ListenAndServe_GRPC_InvalidCertFile(t *testing.T) {
 
 	hoster := gohost.NewHoster()
 	hoster.GRPCAddr = grpcAddr
-	hoster.RegisterGRPCEndpoint(func(s *grpc.Server) {
+	hoster.RegisterGRPCServer(func(s *grpc.Server) {
 		pb.RegisterTestServiceServer(s, service)
 	})
 
@@ -149,7 +149,7 @@ func Test_Hoster_ListenAndServe_GRPC_InvalidKeyFile(t *testing.T) {
 
 	hoster := gohost.NewHoster()
 	hoster.GRPCAddr = grpcAddr
-	hoster.RegisterGRPCEndpoint(func(s *grpc.Server) {
+	hoster.RegisterGRPCServer(func(s *grpc.Server) {
 		pb.RegisterTestServiceServer(s, service)
 	})
 
@@ -172,7 +172,7 @@ func Test_Hoster_ListenAndServe_GRPC_MaxRecvMsgSize_Pass(t *testing.T) {
 
 	hoster := gohost.NewHoster()
 	hoster.GRPCAddr = grpcAddr
-	hoster.RegisterGRPCEndpoint(func(s *grpc.Server) {
+	hoster.RegisterGRPCServer(func(s *grpc.Server) {
 		pb.RegisterTestServiceServer(s, service)
 	})
 
@@ -208,7 +208,7 @@ func Test_Hoster_ListenAndServe_GRPC_MaxRecvMsgSize_Fail(t *testing.T) {
 
 	hoster := gohost.NewHoster()
 	hoster.GRPCAddr = grpcAddr
-	hoster.RegisterGRPCEndpoint(func(s *grpc.Server) {
+	hoster.RegisterGRPCServer(func(s *grpc.Server) {
 		pb.RegisterTestServiceServer(s, service)
 	})
 
@@ -241,7 +241,7 @@ func Test_Hoster_ListenAndServe_GRPC_MaxSendMsgSize_Pass(t *testing.T) {
 
 	hoster := gohost.NewHoster()
 	hoster.GRPCAddr = grpcAddr
-	hoster.RegisterGRPCEndpoint(func(s *grpc.Server) {
+	hoster.RegisterGRPCServer(func(s *grpc.Server) {
 		pb.RegisterTestServiceServer(s, service)
 	})
 
@@ -275,7 +275,7 @@ func Test_Hoster_ListenAndServe_GRPC_MaxSendMsgSize_Fail(t *testing.T) {
 
 	hoster := gohost.NewHoster()
 	hoster.GRPCAddr = grpcAddr
-	hoster.RegisterGRPCEndpoint(func(s *grpc.Server) {
+	hoster.RegisterGRPCServer(func(s *grpc.Server) {
 		pb.RegisterTestServiceServer(s, service)
 	})
 
@@ -310,7 +310,7 @@ func Test_Hoster_ListenAndServe_GRPC_UnaryInterceptor(t *testing.T) {
 
 	hoster := gohost.NewHoster()
 	hoster.GRPCAddr = grpcAddr
-	hoster.RegisterGRPCEndpoint(func(s *grpc.Server) {
+	hoster.RegisterGRPCServer(func(s *grpc.Server) {
 		pb.RegisterTestServiceServer(s, service)
 	})
 
@@ -359,7 +359,7 @@ func Test_Hoster_ListenAndServe_GRPC_StreamInterceptor(t *testing.T) {
 
 	hoster := gohost.NewHoster()
 	hoster.GRPCAddr = grpcAddr
-	hoster.RegisterGRPCEndpoint(func(s *grpc.Server) {
+	hoster.RegisterGRPCServer(func(s *grpc.Server) {
 		pb.RegisterTestServiceServer(s, service)
 	})
 

--- a/test/hoster_http_test.go
+++ b/test/hoster_http_test.go
@@ -29,12 +29,12 @@ func Test_Hoster_ListenAndServe_HTTP_Successful(t *testing.T) {
 
 	hoster := gohost.NewHoster()
 	hoster.GRPCAddr = grpcAddr
-	hoster.RegisterGRPCEndpoint(func(s *grpc.Server) {
+	hoster.RegisterGRPCServer(func(s *grpc.Server) {
 		pb.RegisterTestServiceServer(s, service)
 	})
 
 	hoster.HTTPAddr = httpAddr
-	hoster.RegisterHTTPEndpoint(pb.RegisterTestServiceHandlerFromEndpoint)
+	hoster.RegisterHTTPGateway(pb.RegisterTestServiceHandlerFromEndpoint)
 
 	// act - start the service
 	go hoster.ListenAndServe()
@@ -71,12 +71,12 @@ func Test_Hoster_ListenAndServe_HTTP_WithTLS(t *testing.T) {
 
 	hoster := gohost.NewHoster()
 	hoster.GRPCAddr = grpcAddr
-	hoster.RegisterGRPCEndpoint(func(s *grpc.Server) {
+	hoster.RegisterGRPCServer(func(s *grpc.Server) {
 		pb.RegisterTestServiceServer(s, service)
 	})
 
 	hoster.HTTPAddr = httpAddr
-	hoster.RegisterHTTPEndpoint(pb.RegisterTestServiceHandlerFromEndpoint)
+	hoster.RegisterHTTPGateway(pb.RegisterTestServiceHandlerFromEndpoint)
 
 	hoster.CertFile = "../testdata/test.crt"
 	hoster.KeyFile = "../testdata/test.key"
@@ -117,7 +117,7 @@ func Test_Hoster_ListenAndServe_HTTP_EmptyAddress(t *testing.T) {
 	hoster := gohost.NewHoster()
 
 	hoster.HTTPAddr = ""
-	hoster.RegisterHTTPEndpoint(pb.RegisterTestServiceHandlerFromEndpoint)
+	hoster.RegisterHTTPGateway(pb.RegisterTestServiceHandlerFromEndpoint)
 
 	// act - start the service
 	err := hoster.ListenAndServe()
@@ -131,7 +131,7 @@ func Test_Hoster_ListenAndServe_HTTP_InvalidAddress(t *testing.T) {
 	hoster := gohost.NewHoster()
 
 	hoster.HTTPAddr = "badaddress"
-	hoster.RegisterHTTPEndpoint(pb.RegisterTestServiceHandlerFromEndpoint)
+	hoster.RegisterHTTPGateway(pb.RegisterTestServiceHandlerFromEndpoint)
 
 	// act - start the service
 	err := hoster.ListenAndServe()
@@ -146,7 +146,7 @@ func Test_Hoster_ListenAndServe_HTTP_InvalidCertFile(t *testing.T) {
 	httpAddr := getAddr(t)
 
 	hoster.HTTPAddr = httpAddr
-	hoster.RegisterHTTPEndpoint(pb.RegisterTestServiceHandlerFromEndpoint)
+	hoster.RegisterHTTPGateway(pb.RegisterTestServiceHandlerFromEndpoint)
 
 	hoster.CertFile = "../testdata/badcert.crt"
 	hoster.KeyFile = "../testdata/test.key"
@@ -164,7 +164,7 @@ func Test_Hoster_ListenAndServe_HTTP_InvalidKeyFile(t *testing.T) {
 	httpAddr := getAddr(t)
 
 	hoster.HTTPAddr = httpAddr
-	hoster.RegisterHTTPEndpoint(pb.RegisterTestServiceHandlerFromEndpoint)
+	hoster.RegisterHTTPGateway(pb.RegisterTestServiceHandlerFromEndpoint)
 
 	hoster.CertFile = "../testdata/test.crt"
 	hoster.KeyFile = "../testdata/badkey.key"
@@ -186,12 +186,12 @@ func Test_Hoster_ListenAndServe_HTTP_MaxRecvMsgSize_Pass(t *testing.T) {
 
 	hoster := gohost.NewHoster()
 	hoster.GRPCAddr = grpcAddr
-	hoster.RegisterGRPCEndpoint(func(s *grpc.Server) {
+	hoster.RegisterGRPCServer(func(s *grpc.Server) {
 		pb.RegisterTestServiceServer(s, service)
 	})
 
 	hoster.HTTPAddr = httpAddr
-	hoster.RegisterHTTPEndpoint(pb.RegisterTestServiceHandlerFromEndpoint)
+	hoster.RegisterHTTPGateway(pb.RegisterTestServiceHandlerFromEndpoint)
 
 	hoster.MaxRecvMsgSize = math.MaxInt32
 
@@ -236,12 +236,12 @@ func Test_Hoster_ListenAndServe_HTTP_MaxRecvMsgSize_Fail(t *testing.T) {
 
 	hoster := gohost.NewHoster()
 	hoster.GRPCAddr = grpcAddr
-	hoster.RegisterGRPCEndpoint(func(s *grpc.Server) {
+	hoster.RegisterGRPCServer(func(s *grpc.Server) {
 		pb.RegisterTestServiceServer(s, service)
 	})
 
 	hoster.HTTPAddr = httpAddr
-	hoster.RegisterHTTPEndpoint(pb.RegisterTestServiceHandlerFromEndpoint)
+	hoster.RegisterHTTPGateway(pb.RegisterTestServiceHandlerFromEndpoint)
 
 	hoster.MaxRecvMsgSize = 1
 
@@ -284,12 +284,12 @@ func Test_Hoster_ListenAndServe_HTTP_MaxSendMsgSize_Pass(t *testing.T) {
 
 	hoster := gohost.NewHoster()
 	hoster.GRPCAddr = grpcAddr
-	hoster.RegisterGRPCEndpoint(func(s *grpc.Server) {
+	hoster.RegisterGRPCServer(func(s *grpc.Server) {
 		pb.RegisterTestServiceServer(s, service)
 	})
 
 	hoster.HTTPAddr = httpAddr
-	hoster.RegisterHTTPEndpoint(pb.RegisterTestServiceHandlerFromEndpoint)
+	hoster.RegisterHTTPGateway(pb.RegisterTestServiceHandlerFromEndpoint)
 
 	hoster.MaxSendMsgSize = math.MaxInt32
 
@@ -327,12 +327,12 @@ func Test_Hoster_ListenAndServe_HTTP_MaxSendMsgSize_Fail(t *testing.T) {
 
 	hoster := gohost.NewHoster()
 	hoster.GRPCAddr = grpcAddr
-	hoster.RegisterGRPCEndpoint(func(s *grpc.Server) {
+	hoster.RegisterGRPCServer(func(s *grpc.Server) {
 		pb.RegisterTestServiceServer(s, service)
 	})
 
 	hoster.HTTPAddr = httpAddr
-	hoster.RegisterHTTPEndpoint(pb.RegisterTestServiceHandlerFromEndpoint)
+	hoster.RegisterHTTPGateway(pb.RegisterTestServiceHandlerFromEndpoint)
 
 	hoster.MaxSendMsgSize = 1
 


### PR DESCRIPTION
Rename functions for registering grpc servers and http gateways to increase clarity as to what the methods were actually doing.